### PR TITLE
Proposal: Network Primitives

### DIFF
--- a/jsonschema/src/edges/alley.ts
+++ b/jsonschema/src/edges/alley.ts
@@ -1,11 +1,12 @@
 import { Feature, LineString } from "geojson";
 
+import { BaseEdgeFields } from "./base-edge-fields";
 import { ServiceRoadFields } from "./service-road";
 
 /**
  * Fields that identify an alley.
  */
-interface AlleyIdentifyingFields {
+interface AlleyIdentifyingFields extends BaseEdgeFields {
   highway: "service";
   service: "alley";
 }

--- a/jsonschema/src/edges/base-edge-fields.ts
+++ b/jsonschema/src/edges/base-edge-fields.ts
@@ -1,0 +1,6 @@
+import { NodeID } from "../nodes/base-node-fields";
+
+export interface BaseEdgeFields {
+  _u_id: NodeID;
+  _v_id: NodeID;
+}

--- a/jsonschema/src/edges/crossing.ts
+++ b/jsonschema/src/edges/crossing.ts
@@ -1,11 +1,12 @@
 import { Feature, LineString } from "geojson";
 
+import { BaseEdgeFields } from "./base-edge-fields";
 import { FootwayFields } from "./footway";
 
 /**
  * Fields that identify a crossing.
  */
-interface CrossingIdentifyingFields {
+interface CrossingIdentifyingFields extends BaseEdgeFields {
   highway: "footway";
   footway: "crossing";
 }

--- a/jsonschema/src/edges/cycleway.ts
+++ b/jsonschema/src/edges/cycleway.ts
@@ -1,5 +1,6 @@
 import { Feature, LineString } from "geojson";
 
+import { BaseEdgeFields } from "./base-edge-fields";
 import {
   Brunnel,
   Description,
@@ -15,7 +16,7 @@ import {
 /**
  * Fields that identify a cycleway.
  */
-interface CyclewayIdentifyingFields {
+interface CyclewayIdentifyingFields extends BaseEdgeFields {
   highway: "cycleway";
 }
 

--- a/jsonschema/src/edges/driveway.ts
+++ b/jsonschema/src/edges/driveway.ts
@@ -1,11 +1,12 @@
 import { Feature, LineString } from "geojson";
 
+import { BaseEdgeFields } from "./base-edge-fields";
 import { ServiceRoadFields } from "./service-road";
 
 /**
  * Fields that identify a driveway.
  */
-interface DrivewayIdentifyingFields {
+interface DrivewayIdentifyingFields extends BaseEdgeFields {
   highway: "service";
   service: "driveway";
 }

--- a/jsonschema/src/edges/footway.ts
+++ b/jsonschema/src/edges/footway.ts
@@ -1,5 +1,6 @@
 import { Feature, LineString } from "geojson";
 
+import { BaseEdgeFields } from "./base-edge-fields";
 import {
   Brunnel,
   Description,
@@ -14,7 +15,7 @@ import {
 /**
  * Fields that identify a footway.
  */
-interface FootwayIdentifyingFields {
+interface FootwayIdentifyingFields extends BaseEdgeFields {
   highway: "footway";
 }
 

--- a/jsonschema/src/edges/index.ts
+++ b/jsonschema/src/edges/index.ts
@@ -13,7 +13,7 @@ import { ResidentialStreet } from "./residential-street";
 import { ServiceRoad } from "./service-road";
 import { Driveway } from "./driveway";
 
-export type Pathway =
+export type Edge =
   | Crossing
   | Footway
   | Sidewalk

--- a/jsonschema/src/edges/parking-aisle.ts
+++ b/jsonschema/src/edges/parking-aisle.ts
@@ -1,11 +1,12 @@
 import { Feature, LineString } from "geojson";
 
+import { BaseEdgeFields } from "./base-edge-fields";
 import { ServiceRoadFields } from "./service-road";
 
 /**
  * Fields that identify a parking aisle.
  */
-interface ParkingAisleIdentifyingFields {
+interface ParkingAisleIdentifyingFields extends BaseEdgeFields {
   highway: "service";
   service: "parking_aisle";
 }

--- a/jsonschema/src/edges/primary-street.ts
+++ b/jsonschema/src/edges/primary-street.ts
@@ -1,5 +1,6 @@
 import { Feature, LineString } from "geojson";
 
+import { BaseEdgeFields } from "./base-edge-fields";
 import {
   Brunnel,
   Description,
@@ -15,7 +16,7 @@ import {
 /**
  * Fields that identify a primary street.
  */
-interface PrimaryStreetIdentifyingFields {
+interface PrimaryStreetIdentifyingFields extends BaseEdgeFields {
   highway: "primary";
 }
 

--- a/jsonschema/src/edges/residential-street.ts
+++ b/jsonschema/src/edges/residential-street.ts
@@ -1,5 +1,6 @@
 import { Feature, LineString } from "geojson";
 
+import { BaseEdgeFields } from "./base-edge-fields";
 import {
   Brunnel,
   Description,
@@ -15,7 +16,7 @@ import {
 /**
  * Fields that identify a residential street.
  */
-interface ResidentialStreetIdentifyingFields {
+interface ResidentialStreetIdentifyingFields extends BaseEdgeFields {
   highway: "residential";
 }
 

--- a/jsonschema/src/edges/secondary-street.ts
+++ b/jsonschema/src/edges/secondary-street.ts
@@ -1,5 +1,6 @@
 import { Feature, LineString } from "geojson";
 
+import { BaseEdgeFields } from "./base-edge-fields";
 import {
   Brunnel,
   Description,
@@ -15,7 +16,7 @@ import {
 /**
  * Fields that identify a secondary street.
  */
-interface SecondaryStreetIdentifyingFields {
+interface SecondaryStreetIdentifyingFields extends BaseEdgeFields {
   highway: "secondary";
 }
 

--- a/jsonschema/src/edges/service-road.ts
+++ b/jsonschema/src/edges/service-road.ts
@@ -1,5 +1,6 @@
 import { Feature, LineString } from "geojson";
 
+import { BaseEdgeFields } from "./base-edge-fields";
 import {
   Brunnel,
   Description,
@@ -14,7 +15,7 @@ import {
 /**
  * Fields that identify a service road.
  */
-interface ServiceRoadIdentifyingFields {
+interface ServiceRoadIdentifyingFields extends BaseEdgeFields {
   highway: "service";
 }
 

--- a/jsonschema/src/edges/sidewalk.ts
+++ b/jsonschema/src/edges/sidewalk.ts
@@ -1,11 +1,12 @@
 import { Feature, LineString } from "geojson";
 
+import { BaseEdgeFields } from "./base-edge-fields";
 import { FootwayFields } from "./footway";
 
 /**
  * Fields that identify a sidewalk.
  */
-interface SidewalkIdentifyingFields {
+interface SidewalkIdentifyingFields extends BaseEdgeFields {
   highway: "footway";
   footway: "sidewalk";
 }

--- a/jsonschema/src/edges/tertiary-street.ts
+++ b/jsonschema/src/edges/tertiary-street.ts
@@ -1,5 +1,6 @@
 import { Feature, LineString } from "geojson";
 
+import { BaseEdgeFields } from "./base-edge-fields";
 import {
   Brunnel,
   Description,
@@ -15,7 +16,7 @@ import {
 /**
  * Fields that identify a tertiary street.
  */
-interface TertiaryStreetIdentifyingFields {
+interface TertiaryStreetIdentifyingFields extends BaseEdgeFields {
   highway: "tertiary";
 }
 

--- a/jsonschema/src/edges/traffic-island.ts
+++ b/jsonschema/src/edges/traffic-island.ts
@@ -1,11 +1,12 @@
 import { Feature, LineString } from "geojson";
 
+import { BaseEdgeFields } from "./base-edge-fields";
 import { FootwayFields } from "./footway";
 
 /**
  * Fields that identify a traffic island.
  */
-interface TrafficIslandIdentifyingFields {
+interface TrafficIslandIdentifyingFields extends BaseEdgeFields {
   highway: "footway";
   footway: "traffic_island";
 }

--- a/jsonschema/src/fields.ts
+++ b/jsonschema/src/fields.ts
@@ -7,16 +7,16 @@ export type Brunnel = "bridge" | "ford" | "tunnel";
  */
 export type Crossing = "marked" | "unmarked";
 /**
- * A free form text field for describing a pathway or point. May be pre-encoded in relevant pedestrian paths to assist with routing instructing or investigation of map features. For example, a description of the sidewalk in relation to a nearby street may be a useful textual description, such as "NE of Main St." Can also be considered a flexible location to embed arbitrary information for specific use cases.
+ * A free form text field for describing an edge of node. May be pre-encoded in relevant pedestrian paths to assist with routing instructing or investigation of map features. For example, a description of the sidewalk in relation to a nearby street may be a useful textual description, such as "NE of Main St." Can also be considered a flexible location to embed arbitrary information for specific use cases.
  */
 export type Description = string;
 /**
- * A field for whether a pathway uses an elevator for vertical movement, e.g. building
+ * A field for whether an edge uses an elevator for vertical movement, e.g. building
 paths.
  */
 export type Elevator = boolean;
 /**
- * A field that indicates whether a pathway can be used by pedestrians. Is implied for a Footway entity and its subtypes.
+ * A field that indicates whether an edge can be used by pedestrians. Is implied for a Footway entity and its subtypes.
  */
 export type Foot = boolean;
 /**
@@ -26,28 +26,28 @@ export type Foot = boolean;
  */
 export type Incline = number;
 /**
- * A field that indicates whether a pathway is indoors.
+ * A field that indicates whether an edge is indoors.
  */
 export type Indoor = boolean;
 /**
- * A field that indicates the z-layer (integer) on which a pathway lies. If unset, a value of 0 is implied. Negative values are allowed.
+ * A field that indicates the z-layer (integer) on which an edge lies. If unset, a value of 0 is implied. Negative values are allowed.
  * @TJS-type integer
  * @minimum -10
  * @maximum 10
  */
 export type Layer = number;
 /**
- * A field for the length of a pathway in meters. This field is always inferred from the geometry.
+ * A field for the length of an edge in meters. This field is always inferred from the geometry.
  * @minimum 0
  * @maximum 5000
  */
 export type Length = number;
 /**
- * A field for a designated name for a pathway. Example: an official name for a trail.
+ * A field for a designated name for an edge. Example: an official name for a trail.
  */
 export type Name = string;
 /**
- * A field for the opening hours of an entity: whether it is available at a given time. A pathway through a building that closes at night, for example, may have this field. The value is in OpenStreetMap syntax for the opening\_hours tag. See [OpenStreetMap specification](https://wiki.openstreetmap.org/wiki/Key:opening_hours/specification) on the formatting for this field.
+ * A field for the opening hours of an entity: whether it is available at a given time. An edge through a building that closes at night, for example, may have this field. The value is in OpenStreetMap syntax for the opening\_hours tag. See [OpenStreetMap specification](https://wiki.openstreetmap.org/wiki/Key:opening_hours/specification) on the formatting for this field.
  */
 export type OpeningHours = string;
 /**
@@ -62,11 +62,11 @@ export type Surface =
   | "paving_stones"
   | "unpaved";
 /**
- * A field for whether a curb ramp or pathway has a tactile (textured) surface.
+ * A field for whether a curb ramp or edge has a tactile (textured) surface.
  */
 export type TactilePaving = boolean;
 /**
- * A field for width of a pathway in meters.
+ * A field for width of an edge in meters.
  * @minimum 0
  * @maximum 500
  */

--- a/jsonschema/src/nodes/bare-node.ts
+++ b/jsonschema/src/nodes/bare-node.ts
@@ -1,0 +1,18 @@
+import { Feature, Point } from "geojson";
+
+import { BaseNodeFields } from "./base-node-fields";
+
+/**
+ * Fields that identify a bare node.
+ */
+interface BareNodeIdentifyingFields extends BaseNodeFields {}
+
+/**
+ * Fields that apply to a bare node (none beyond _id).
+ */
+interface BareNodeFields extends BareNodeIdentifyingFields {}
+
+/**
+ * A node that is merely part of the graph structure but has no metadata or meaning of its own. For example, a sidewalk may be split into two edges because they have differing widths, so they must be joined by a node - but there is no data to place on the node itself beyond basic spatial and graph primitives.
+ */
+export type BareNode = Feature<Point, BareNodeFields>;

--- a/jsonschema/src/nodes/base-node-fields.ts
+++ b/jsonschema/src/nodes/base-node-fields.ts
@@ -1,0 +1,9 @@
+// All Nodes must defined an _id, serving as a unique identifier of that node.
+// This comports with a graph theoretic definition of a vertex, where we need
+// a way to define the node as a member of the vertex set.
+
+export type NodeID = string;
+
+export interface BaseNodeFields {
+  _id: NodeID;
+}

--- a/jsonschema/src/nodes/curb-ramp.ts
+++ b/jsonschema/src/nodes/curb-ramp.ts
@@ -1,11 +1,12 @@
 import { Feature, Point } from "geojson";
 
+import { BaseNodeFields } from "./base-node-fields";
 import { Brunnel, Layer, Surface, TactilePaving } from "../fields";
 
 /**
  * Fields that identify a curb ramp.
  */
-interface CurbRampIdentifyingFields {
+interface CurbRampIdentifyingFields extends BaseNodeFields {
   kerb: "lowered";
 }
 
@@ -20,7 +21,7 @@ interface CurbRampFields extends CurbRampIdentifyingFields {
 }
 
 /**
- * A curb ramp (curb cut) mapped as a curb interface. Mapped at the location where the two pathways that it connects meet one another.
+ * A curb ramp (curb cut) mapped as a curb interface. Mapped at the location where the two edges that it connects meet one another.
  *
  */
 export type CurbRamp = Feature<Point, CurbRampFields>;

--- a/jsonschema/src/nodes/flush-curb.ts
+++ b/jsonschema/src/nodes/flush-curb.ts
@@ -1,11 +1,12 @@
 import { Feature, Point } from "geojson";
 
+import { BaseNodeFields } from "./base-node-fields";
 import { Brunnel, Layer } from "../fields";
 
 /**
  * Fields that identify a flush curb.
  */
-interface FlushCurbIdentifyingFields {
+interface FlushCurbIdentifyingFields extends BaseNodeFields {
   kerb: "flush";
 }
 

--- a/jsonschema/src/nodes/index.ts
+++ b/jsonschema/src/nodes/index.ts
@@ -1,0 +1,13 @@
+// Nodes are networky/graphy: they contain a unique identifier that is
+// referenced by edges. This is in contrast to Points, which are free-floating
+// geospatial elements and not an explicit part of the graph structure.
+
+// TODO: Create a derived Feature type that requires an extension of the
+// required Node fields.
+import { BareNode } from "./bare-node";
+import { CurbRamp } from "./curb-ramp";
+import { FlushCurb } from "./flush-curb";
+import { RaisedCurb } from "./raised-curb";
+import { RolledCurb } from "./rolled-curb";
+
+export type Node = BareNode | CurbRamp | FlushCurb | RaisedCurb | RolledCurb;

--- a/jsonschema/src/nodes/raised-curb.ts
+++ b/jsonschema/src/nodes/raised-curb.ts
@@ -1,11 +1,12 @@
 import { Feature, Point } from "geojson";
 
+import { BaseNodeFields } from "./base-node-fields";
 import { Brunnel, Layer } from "../fields";
 
 /**
  * Fields that identify a raised curb.
  */
-interface RaisedCurbIdentifyingFields {
+interface RaisedCurbIdentifyingFields extends BaseNodeFields {
   kerb: "rolled";
 }
 
@@ -18,6 +19,6 @@ interface RaisedCurbFields extends RaisedCurbIdentifyingFields {
 }
 
 /**
- * A single, designed vertical displacement that separates two pathways. A common example is the curb that separates a street crossing from a sidewalk. This is mapped at the point where the two paths meet - on top of the curb is physically located.
+ * A single, designed vertical displacement that separates two edges. A common example is the curb that separates a street crossing from a sidewalk. This is mapped at the point where the two edges meet - on top of the curb is physically located.
  */
 export type RaisedCurb = Feature<Point, RaisedCurbFields>;

--- a/jsonschema/src/nodes/rolled-curb.ts
+++ b/jsonschema/src/nodes/rolled-curb.ts
@@ -1,11 +1,12 @@
 import { Feature, Point } from "geojson";
 
+import { BaseNodeFields } from "./base-node-fields";
 import { Brunnel, Layer } from "../fields";
 
 /**
  * Fields that identify a rolled curb.
  */
-interface RolledCurbIdentifyingFields {
+interface RolledCurbIdentifyingFields extends BaseNodeFields {
   kerb: "rolled";
 }
 
@@ -18,6 +19,6 @@ interface RolledCurbFields extends RolledCurbIdentifyingFields {
 }
 
 /**
- * A curb interface with a quarter-circle profile: traversing this curb is like going over half of a bump. Located where two pathways meet, physically at the location of the curb itself.
+ * A curb interface with a quarter-circle profile: traversing this curb is like going over half of a bump. Located where two edges meet, physically at the location of the curb itself.
  */
 export type RolledCurb = Feature<Point, RolledCurbFields>;

--- a/jsonschema/src/opensidewalks-feature-collection.ts
+++ b/jsonschema/src/opensidewalks-feature-collection.ts
@@ -1,7 +1,7 @@
-import { Point } from "./points";
-import { Pathway } from "./pathways";
+import { Node } from "./nodes";
+import { Edge } from "./edges";
 
 export interface OpenSidewalksFeatureCollection {
   type: "FeatureCollection";
-  features: (Point | Pathway)[];
+  features: (Node | Edge)[];
 }

--- a/jsonschema/src/points/index.ts
+++ b/jsonschema/src/points/index.ts
@@ -1,14 +1,11 @@
-import { CurbRamp } from "./curb-ramp";
+// Points are geospatial point features that are not explicitly associated with
+// the graph. They are still of interest to pedestrian datasets, however, and
+// may be queried relative to the graph using spatial relationships, e.g.
+// "all fire hydrants within 3 meters of this sidewalk".
+
 import { FireHydrant } from "./fire-hydrant";
-import { FlushCurb } from "./flush-curb";
 import { PowerPole } from "./power-pole";
-import { RaisedCurb } from "./raised-curb";
-import { RolledCurb } from "./rolled-curb";
 
 export type Point =
-  | CurbRamp
   | FireHydrant
-  | FlushCurb
-  | PowerPole
-  | RaisedCurb
-  | RolledCurb;
+  | PowerPole;

--- a/opensidewalks.schema.json
+++ b/opensidewalks.schema.json
@@ -2,6 +2,102 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "additionalProperties": false,
     "definitions": {
+        "BareNode": {
+            "additionalProperties": false,
+            "description": "A node that is merely part of the graph structure but has no metadata or meaning of its own. For example, a sidewalk may be split into two edges because they have differing widths, so they must be joined by a node - but there is no data to place on the node itself beyond basic spatial and graph primitives.",
+            "properties": {
+                "bbox": {
+                    "anyOf": [
+                        {
+                            "items": [
+                                {
+                                    "type": "number"
+                                },
+                                {
+                                    "type": "number"
+                                },
+                                {
+                                    "type": "number"
+                                },
+                                {
+                                    "type": "number"
+                                }
+                            ],
+                            "maxItems": 4,
+                            "minItems": 4,
+                            "type": "array"
+                        },
+                        {
+                            "items": [
+                                {
+                                    "type": "number"
+                                },
+                                {
+                                    "type": "number"
+                                },
+                                {
+                                    "type": "number"
+                                },
+                                {
+                                    "type": "number"
+                                },
+                                {
+                                    "type": "number"
+                                },
+                                {
+                                    "type": "number"
+                                }
+                            ],
+                            "maxItems": 6,
+                            "minItems": 6,
+                            "type": "array"
+                        }
+                    ],
+                    "description": "Bounding box of the coordinate range of the object's Geometries, Features, or Feature Collections.\nThe value of the bbox member is an array of length 2*n where n is the number of dimensions\nrepresented in the contained geometries, with all axes of the most southwesterly point\nfollowed by all axes of the more northeasterly point.\nThe axes order of a bbox follows the axes order of geometries.\nhttps://tools.ietf.org/html/rfc7946#section-5"
+                },
+                "geometry": {
+                    "$ref": "#/definitions/GeoJSON.Point",
+                    "description": "The feature's geometry"
+                },
+                "id": {
+                    "description": "A value that uniquely identifies this feature in a\nhttps://tools.ietf.org/html/rfc7946#section-3.2.",
+                    "type": [
+                        "string",
+                        "number"
+                    ]
+                },
+                "properties": {
+                    "$ref": "#/definitions/BareNodeFields",
+                    "description": "Properties associated with this feature."
+                },
+                "type": {
+                    "description": "Specifies the type of GeoJSON object.",
+                    "enum": [
+                        "Feature"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "geometry",
+                "properties",
+                "type"
+            ],
+            "type": "object"
+        },
+        "BareNodeFields": {
+            "additionalProperties": false,
+            "description": "Fields that apply to a bare node (none beyond _id).",
+            "properties": {
+                "_id": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "_id"
+            ],
+            "type": "object"
+        },
         "Crossing": {
             "additionalProperties": false,
             "description": "The centerline of a pedestrian street crossing. This path exists only on the road surface itself, i.e. \"from curb to curb\". Crossings should not be connected directly to sidewalk centerlines - instead, a short footpath (this schema calls them \"links\") should connect the two together.",
@@ -89,6 +185,12 @@
             "additionalProperties": false,
             "description": "Fields that apply to a crossing.",
             "properties": {
+                "_u_id": {
+                    "type": "string"
+                },
+                "_v_id": {
+                    "type": "string"
+                },
                 "brunnel": {
                     "description": "A field that indicates whether an entity is on a bridge, tunnel, or ford.",
                     "enum": [
@@ -106,7 +208,7 @@
                     "type": "string"
                 },
                 "description": {
-                    "description": "A free form text field for describing a pathway or point. May be pre-encoded in relevant pedestrian paths to assist with routing instructing or investigation of map features. For example, a description of the sidewalk in relation to a nearby street may be a useful textual description, such as \"NE of Main St.\" Can also be considered a flexible location to embed arbitrary information for specific use cases.",
+                    "description": "A free form text field for describing an edge of node. May be pre-encoded in relevant pedestrian paths to assist with routing instructing or investigation of map features. For example, a description of the sidewalk in relation to a nearby street may be a useful textual description, such as \"NE of Main St.\" Can also be considered a flexible location to embed arbitrary information for specific use cases.",
                     "type": "string"
                 },
                 "footway": {
@@ -128,19 +230,19 @@
                     "type": "number"
                 },
                 "layer": {
-                    "description": "A field that indicates the z-layer (integer) on which a pathway lies. If unset, a value of 0 is implied. Negative values are allowed.",
+                    "description": "A field that indicates the z-layer (integer) on which an edge lies. If unset, a value of 0 is implied. Negative values are allowed.",
                     "maximum": 10,
                     "minimum": -10,
                     "type": "integer"
                 },
                 "length": {
-                    "description": "A field for the length of a pathway in meters. This field is always inferred from the geometry.",
+                    "description": "A field for the length of an edge in meters. This field is always inferred from the geometry.",
                     "maximum": 5000,
                     "minimum": 0,
                     "type": "number"
                 },
                 "name": {
-                    "description": "A field for a designated name for a pathway. Example: an official name for a trail.",
+                    "description": "A field for a designated name for an edge. Example: an official name for a trail.",
                     "type": "string"
                 },
                 "surface": {
@@ -157,13 +259,15 @@
                     "type": "string"
                 },
                 "width": {
-                    "description": "A field for width of a pathway in meters.",
+                    "description": "A field for width of an edge in meters.",
                     "maximum": 500,
                     "minimum": 0,
                     "type": "number"
                 }
             },
             "required": [
+                "_u_id",
+                "_v_id",
                 "footway",
                 "highway"
             ],
@@ -171,7 +275,7 @@
         },
         "CurbRamp": {
             "additionalProperties": false,
-            "description": "A curb ramp (curb cut) mapped as a curb interface. Mapped at the location where the two pathways that it connects meet one another.",
+            "description": "A curb ramp (curb cut) mapped as a curb interface. Mapped at the location where the two edges that it connects meet one another.",
             "properties": {
                 "bbox": {
                     "anyOf": [
@@ -256,6 +360,9 @@
             "additionalProperties": false,
             "description": "Fields that apply to a curb ramp.",
             "properties": {
+                "_id": {
+                    "type": "string"
+                },
                 "brunnel": {
                     "description": "A field that indicates whether an entity is on a bridge, tunnel, or ford.",
                     "enum": [
@@ -272,7 +379,7 @@
                     "type": "string"
                 },
                 "layer": {
-                    "description": "A field that indicates the z-layer (integer) on which a pathway lies. If unset, a value of 0 is implied. Negative values are allowed.",
+                    "description": "A field that indicates the z-layer (integer) on which an edge lies. If unset, a value of 0 is implied. Negative values are allowed.",
                     "maximum": 10,
                     "minimum": -10,
                     "type": "integer"
@@ -291,11 +398,12 @@
                     "type": "string"
                 },
                 "tactile_paving": {
-                    "description": "A field for whether a curb ramp or pathway has a tactile (textured) surface.",
+                    "description": "A field for whether a curb ramp or edge has a tactile (textured) surface.",
                     "type": "boolean"
                 }
             },
             "required": [
+                "_id",
                 "kerb"
             ],
             "type": "object"
@@ -386,6 +494,12 @@
         "CyclewayFields": {
             "additionalProperties": false,
             "properties": {
+                "_u_id": {
+                    "type": "string"
+                },
+                "_v_id": {
+                    "type": "string"
+                },
                 "brunnel": {
                     "description": "Fields that apply to a cycleway.",
                     "enum": [
@@ -396,11 +510,11 @@
                     "type": "string"
                 },
                 "description": {
-                    "description": "A free form text field for describing a pathway or point. May be pre-encoded in relevant pedestrian paths to assist with routing instructing or investigation of map features. For example, a description of the sidewalk in relation to a nearby street may be a useful textual description, such as \"NE of Main St.\" Can also be considered a flexible location to embed arbitrary information for specific use cases.",
+                    "description": "A free form text field for describing an edge of node. May be pre-encoded in relevant pedestrian paths to assist with routing instructing or investigation of map features. For example, a description of the sidewalk in relation to a nearby street may be a useful textual description, such as \"NE of Main St.\" Can also be considered a flexible location to embed arbitrary information for specific use cases.",
                     "type": "string"
                 },
                 "foot": {
-                    "description": "A field that indicates whether a pathway can be used by pedestrians. Is implied for a Footway entity and its subtypes.",
+                    "description": "A field that indicates whether an edge can be used by pedestrians. Is implied for a Footway entity and its subtypes.",
                     "type": "boolean"
                 },
                 "highway": {
@@ -416,19 +530,19 @@
                     "type": "number"
                 },
                 "layer": {
-                    "description": "A field that indicates the z-layer (integer) on which a pathway lies. If unset, a value of 0 is implied. Negative values are allowed.",
+                    "description": "A field that indicates the z-layer (integer) on which an edge lies. If unset, a value of 0 is implied. Negative values are allowed.",
                     "maximum": 10,
                     "minimum": -10,
                     "type": "integer"
                 },
                 "length": {
-                    "description": "A field for the length of a pathway in meters. This field is always inferred from the geometry.",
+                    "description": "A field for the length of an edge in meters. This field is always inferred from the geometry.",
                     "maximum": 5000,
                     "minimum": 0,
                     "type": "number"
                 },
                 "name": {
-                    "description": "A field for a designated name for a pathway. Example: an official name for a trail.",
+                    "description": "A field for a designated name for an edge. Example: an official name for a trail.",
                     "type": "string"
                 },
                 "surface": {
@@ -445,13 +559,15 @@
                     "type": "string"
                 },
                 "width": {
-                    "description": "A field for width of a pathway in meters.",
+                    "description": "A field for width of an edge in meters.",
                     "maximum": 500,
                     "minimum": 0,
                     "type": "number"
                 }
             },
             "required": [
+                "_u_id",
+                "_v_id",
                 "highway"
             ],
             "type": "object"
@@ -524,6 +640,12 @@
                     "additionalProperties": false,
                     "description": "Properties associated with this feature.",
                     "properties": {
+                        "_u_id": {
+                            "type": "string"
+                        },
+                        "_v_id": {
+                            "type": "string"
+                        },
                         "highway": {
                             "enum": [
                                 "service"
@@ -538,6 +660,8 @@
                         }
                     },
                     "required": [
+                        "_u_id",
+                        "_v_id",
                         "highway",
                         "service"
                     ]
@@ -554,120 +678,6 @@
                 "geometry",
                 "properties",
                 "type"
-            ],
-            "type": "object"
-        },
-        "FireHydrant": {
-            "additionalProperties": false,
-            "description": "A fire hydrant - where fire response teams connect high-pressure hoses.",
-            "properties": {
-                "bbox": {
-                    "anyOf": [
-                        {
-                            "items": [
-                                {
-                                    "type": "number"
-                                },
-                                {
-                                    "type": "number"
-                                },
-                                {
-                                    "type": "number"
-                                },
-                                {
-                                    "type": "number"
-                                }
-                            ],
-                            "maxItems": 4,
-                            "minItems": 4,
-                            "type": "array"
-                        },
-                        {
-                            "items": [
-                                {
-                                    "type": "number"
-                                },
-                                {
-                                    "type": "number"
-                                },
-                                {
-                                    "type": "number"
-                                },
-                                {
-                                    "type": "number"
-                                },
-                                {
-                                    "type": "number"
-                                },
-                                {
-                                    "type": "number"
-                                }
-                            ],
-                            "maxItems": 6,
-                            "minItems": 6,
-                            "type": "array"
-                        }
-                    ],
-                    "description": "Bounding box of the coordinate range of the object's Geometries, Features, or Feature Collections.\nThe value of the bbox member is an array of length 2*n where n is the number of dimensions\nrepresented in the contained geometries, with all axes of the most southwesterly point\nfollowed by all axes of the more northeasterly point.\nThe axes order of a bbox follows the axes order of geometries.\nhttps://tools.ietf.org/html/rfc7946#section-5"
-                },
-                "geometry": {
-                    "$ref": "#/definitions/GeoJSON.Point",
-                    "description": "The feature's geometry"
-                },
-                "id": {
-                    "description": "A value that uniquely identifies this feature in a\nhttps://tools.ietf.org/html/rfc7946#section-3.2.",
-                    "type": [
-                        "string",
-                        "number"
-                    ]
-                },
-                "properties": {
-                    "$ref": "#/definitions/FireHydrantFields",
-                    "description": "Properties associated with this feature."
-                },
-                "type": {
-                    "description": "Specifies the type of GeoJSON object.",
-                    "enum": [
-                        "Feature"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "geometry",
-                "properties",
-                "type"
-            ],
-            "type": "object"
-        },
-        "FireHydrantFields": {
-            "additionalProperties": false,
-            "description": "Fields that apply to a fire hydrant.",
-            "properties": {
-                "brunnel": {
-                    "description": "A field that indicates whether an entity is on a bridge, tunnel, or ford.",
-                    "enum": [
-                        "bridge",
-                        "ford",
-                        "tunnel"
-                    ],
-                    "type": "string"
-                },
-                "emergency": {
-                    "enum": [
-                        "fire_hydrant"
-                    ],
-                    "type": "string"
-                },
-                "layer": {
-                    "description": "A field that indicates the z-layer (integer) on which a pathway lies. If unset, a value of 0 is implied. Negative values are allowed.",
-                    "maximum": 10,
-                    "minimum": -10,
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "emergency"
             ],
             "type": "object"
         },
@@ -758,6 +768,9 @@
             "additionalProperties": false,
             "description": "Fields that apply to a flush curb.",
             "properties": {
+                "_id": {
+                    "type": "string"
+                },
                 "brunnel": {
                     "description": "A field that indicates whether an entity is on a bridge, tunnel, or ford.",
                     "enum": [
@@ -774,13 +787,14 @@
                     "type": "string"
                 },
                 "layer": {
-                    "description": "A field that indicates the z-layer (integer) on which a pathway lies. If unset, a value of 0 is implied. Negative values are allowed.",
+                    "description": "A field that indicates the z-layer (integer) on which an edge lies. If unset, a value of 0 is implied. Negative values are allowed.",
                     "maximum": 10,
                     "minimum": -10,
                     "type": "integer"
                 }
             },
             "required": [
+                "_id",
                 "kerb"
             ],
             "type": "object"
@@ -872,6 +886,12 @@
             "additionalProperties": false,
             "description": "Fields that apply to a footway.",
             "properties": {
+                "_u_id": {
+                    "type": "string"
+                },
+                "_v_id": {
+                    "type": "string"
+                },
                 "brunnel": {
                     "description": "A field that indicates whether an entity is on a bridge, tunnel, or ford.",
                     "enum": [
@@ -882,7 +902,7 @@
                     "type": "string"
                 },
                 "description": {
-                    "description": "A free form text field for describing a pathway or point. May be pre-encoded in relevant pedestrian paths to assist with routing instructing or investigation of map features. For example, a description of the sidewalk in relation to a nearby street may be a useful textual description, such as \"NE of Main St.\" Can also be considered a flexible location to embed arbitrary information for specific use cases.",
+                    "description": "A free form text field for describing an edge of node. May be pre-encoded in relevant pedestrian paths to assist with routing instructing or investigation of map features. For example, a description of the sidewalk in relation to a nearby street may be a useful textual description, such as \"NE of Main St.\" Can also be considered a flexible location to embed arbitrary information for specific use cases.",
                     "type": "string"
                 },
                 "highway": {
@@ -898,19 +918,19 @@
                     "type": "number"
                 },
                 "layer": {
-                    "description": "A field that indicates the z-layer (integer) on which a pathway lies. If unset, a value of 0 is implied. Negative values are allowed.",
+                    "description": "A field that indicates the z-layer (integer) on which an edge lies. If unset, a value of 0 is implied. Negative values are allowed.",
                     "maximum": 10,
                     "minimum": -10,
                     "type": "integer"
                 },
                 "length": {
-                    "description": "A field for the length of a pathway in meters. This field is always inferred from the geometry.",
+                    "description": "A field for the length of an edge in meters. This field is always inferred from the geometry.",
                     "maximum": 5000,
                     "minimum": 0,
                     "type": "number"
                 },
                 "name": {
-                    "description": "A field for a designated name for a pathway. Example: an official name for a trail.",
+                    "description": "A field for a designated name for an edge. Example: an official name for a trail.",
                     "type": "string"
                 },
                 "surface": {
@@ -927,13 +947,15 @@
                     "type": "string"
                 },
                 "width": {
-                    "description": "A field for width of a pathway in meters.",
+                    "description": "A field for width of an edge in meters.",
                     "maximum": 500,
                     "minimum": 0,
                     "type": "number"
                 }
             },
             "required": [
+                "_u_id",
+                "_v_id",
                 "highway"
             ],
             "type": "object"
@@ -1089,120 +1111,6 @@
             ],
             "type": "object"
         },
-        "PowerPole": {
-            "additionalProperties": false,
-            "description": "A power pole. Often made of wood or metal, they hold power lines.",
-            "properties": {
-                "bbox": {
-                    "anyOf": [
-                        {
-                            "items": [
-                                {
-                                    "type": "number"
-                                },
-                                {
-                                    "type": "number"
-                                },
-                                {
-                                    "type": "number"
-                                },
-                                {
-                                    "type": "number"
-                                }
-                            ],
-                            "maxItems": 4,
-                            "minItems": 4,
-                            "type": "array"
-                        },
-                        {
-                            "items": [
-                                {
-                                    "type": "number"
-                                },
-                                {
-                                    "type": "number"
-                                },
-                                {
-                                    "type": "number"
-                                },
-                                {
-                                    "type": "number"
-                                },
-                                {
-                                    "type": "number"
-                                },
-                                {
-                                    "type": "number"
-                                }
-                            ],
-                            "maxItems": 6,
-                            "minItems": 6,
-                            "type": "array"
-                        }
-                    ],
-                    "description": "Bounding box of the coordinate range of the object's Geometries, Features, or Feature Collections.\nThe value of the bbox member is an array of length 2*n where n is the number of dimensions\nrepresented in the contained geometries, with all axes of the most southwesterly point\nfollowed by all axes of the more northeasterly point.\nThe axes order of a bbox follows the axes order of geometries.\nhttps://tools.ietf.org/html/rfc7946#section-5"
-                },
-                "geometry": {
-                    "$ref": "#/definitions/GeoJSON.Point",
-                    "description": "The feature's geometry"
-                },
-                "id": {
-                    "description": "A value that uniquely identifies this feature in a\nhttps://tools.ietf.org/html/rfc7946#section-3.2.",
-                    "type": [
-                        "string",
-                        "number"
-                    ]
-                },
-                "properties": {
-                    "$ref": "#/definitions/PowerPoleFields",
-                    "description": "Properties associated with this feature."
-                },
-                "type": {
-                    "description": "Specifies the type of GeoJSON object.",
-                    "enum": [
-                        "Feature"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "geometry",
-                "properties",
-                "type"
-            ],
-            "type": "object"
-        },
-        "PowerPoleFields": {
-            "additionalProperties": false,
-            "description": "Fields that apply to a power pole.",
-            "properties": {
-                "brunnel": {
-                    "description": "A field that indicates whether an entity is on a bridge, tunnel, or ford.",
-                    "enum": [
-                        "bridge",
-                        "ford",
-                        "tunnel"
-                    ],
-                    "type": "string"
-                },
-                "layer": {
-                    "description": "A field that indicates the z-layer (integer) on which a pathway lies. If unset, a value of 0 is implied. Negative values are allowed.",
-                    "maximum": 10,
-                    "minimum": -10,
-                    "type": "integer"
-                },
-                "power": {
-                    "enum": [
-                        "pole"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "power"
-            ],
-            "type": "object"
-        },
         "PrimaryStreet": {
             "additionalProperties": false,
             "description": "The centerline of a major highway.",
@@ -1290,6 +1198,12 @@
             "additionalProperties": false,
             "description": "Fields that apply to a primary street.",
             "properties": {
+                "_u_id": {
+                    "type": "string"
+                },
+                "_v_id": {
+                    "type": "string"
+                },
                 "brunnel": {
                     "description": "A field that indicates whether an entity is on a bridge, tunnel, or ford.",
                     "enum": [
@@ -1300,11 +1214,11 @@
                     "type": "string"
                 },
                 "description": {
-                    "description": "A free form text field for describing a pathway or point. May be pre-encoded in relevant pedestrian paths to assist with routing instructing or investigation of map features. For example, a description of the sidewalk in relation to a nearby street may be a useful textual description, such as \"NE of Main St.\" Can also be considered a flexible location to embed arbitrary information for specific use cases.",
+                    "description": "A free form text field for describing an edge of node. May be pre-encoded in relevant pedestrian paths to assist with routing instructing or investigation of map features. For example, a description of the sidewalk in relation to a nearby street may be a useful textual description, such as \"NE of Main St.\" Can also be considered a flexible location to embed arbitrary information for specific use cases.",
                     "type": "string"
                 },
                 "foot": {
-                    "description": "A field that indicates whether a pathway can be used by pedestrians. Is implied for a Footway entity and its subtypes.",
+                    "description": "A field that indicates whether an edge can be used by pedestrians. Is implied for a Footway entity and its subtypes.",
                     "type": "boolean"
                 },
                 "highway": {
@@ -1320,19 +1234,19 @@
                     "type": "number"
                 },
                 "layer": {
-                    "description": "A field that indicates the z-layer (integer) on which a pathway lies. If unset, a value of 0 is implied. Negative values are allowed.",
+                    "description": "A field that indicates the z-layer (integer) on which an edge lies. If unset, a value of 0 is implied. Negative values are allowed.",
                     "maximum": 10,
                     "minimum": -10,
                     "type": "integer"
                 },
                 "length": {
-                    "description": "A field for the length of a pathway in meters. This field is always inferred from the geometry.",
+                    "description": "A field for the length of an edge in meters. This field is always inferred from the geometry.",
                     "maximum": 5000,
                     "minimum": 0,
                     "type": "number"
                 },
                 "name": {
-                    "description": "A field for a designated name for a pathway. Example: an official name for a trail.",
+                    "description": "A field for a designated name for an edge. Example: an official name for a trail.",
                     "type": "string"
                 },
                 "surface": {
@@ -1349,20 +1263,22 @@
                     "type": "string"
                 },
                 "width": {
-                    "description": "A field for width of a pathway in meters.",
+                    "description": "A field for width of an edge in meters.",
                     "maximum": 500,
                     "minimum": 0,
                     "type": "number"
                 }
             },
             "required": [
+                "_u_id",
+                "_v_id",
                 "highway"
             ],
             "type": "object"
         },
         "RaisedCurb": {
             "additionalProperties": false,
-            "description": "A single, designed vertical displacement that separates two pathways. A common example is the curb that separates a street crossing from a sidewalk. This is mapped at the point where the two paths meet - on top of the curb is physically located.",
+            "description": "A single, designed vertical displacement that separates two edges. A common example is the curb that separates a street crossing from a sidewalk. This is mapped at the point where the two edges meet - on top of the curb is physically located.",
             "properties": {
                 "bbox": {
                     "anyOf": [
@@ -1447,6 +1363,9 @@
             "additionalProperties": false,
             "description": "Fields that apply to a raised curb.",
             "properties": {
+                "_id": {
+                    "type": "string"
+                },
                 "brunnel": {
                     "description": "A field that indicates whether an entity is on a bridge, tunnel, or ford.",
                     "enum": [
@@ -1463,13 +1382,14 @@
                     "type": "string"
                 },
                 "layer": {
-                    "description": "A field that indicates the z-layer (integer) on which a pathway lies. If unset, a value of 0 is implied. Negative values are allowed.",
+                    "description": "A field that indicates the z-layer (integer) on which an edge lies. If unset, a value of 0 is implied. Negative values are allowed.",
                     "maximum": 10,
                     "minimum": -10,
                     "type": "integer"
                 }
             },
             "required": [
+                "_id",
                 "kerb"
             ],
             "type": "object"
@@ -1561,6 +1481,12 @@
             "additionalProperties": false,
             "description": "Fields that apply to a residential street.",
             "properties": {
+                "_u_id": {
+                    "type": "string"
+                },
+                "_v_id": {
+                    "type": "string"
+                },
                 "brunnel": {
                     "description": "A field that indicates whether an entity is on a bridge, tunnel, or ford.",
                     "enum": [
@@ -1571,11 +1497,11 @@
                     "type": "string"
                 },
                 "description": {
-                    "description": "A free form text field for describing a pathway or point. May be pre-encoded in relevant pedestrian paths to assist with routing instructing or investigation of map features. For example, a description of the sidewalk in relation to a nearby street may be a useful textual description, such as \"NE of Main St.\" Can also be considered a flexible location to embed arbitrary information for specific use cases.",
+                    "description": "A free form text field for describing an edge of node. May be pre-encoded in relevant pedestrian paths to assist with routing instructing or investigation of map features. For example, a description of the sidewalk in relation to a nearby street may be a useful textual description, such as \"NE of Main St.\" Can also be considered a flexible location to embed arbitrary information for specific use cases.",
                     "type": "string"
                 },
                 "foot": {
-                    "description": "A field that indicates whether a pathway can be used by pedestrians. Is implied for a Footway entity and its subtypes.",
+                    "description": "A field that indicates whether an edge can be used by pedestrians. Is implied for a Footway entity and its subtypes.",
                     "type": "boolean"
                 },
                 "highway": {
@@ -1591,19 +1517,19 @@
                     "type": "number"
                 },
                 "layer": {
-                    "description": "A field that indicates the z-layer (integer) on which a pathway lies. If unset, a value of 0 is implied. Negative values are allowed.",
+                    "description": "A field that indicates the z-layer (integer) on which an edge lies. If unset, a value of 0 is implied. Negative values are allowed.",
                     "maximum": 10,
                     "minimum": -10,
                     "type": "integer"
                 },
                 "length": {
-                    "description": "A field for the length of a pathway in meters. This field is always inferred from the geometry.",
+                    "description": "A field for the length of an edge in meters. This field is always inferred from the geometry.",
                     "maximum": 5000,
                     "minimum": 0,
                     "type": "number"
                 },
                 "name": {
-                    "description": "A field for a designated name for a pathway. Example: an official name for a trail.",
+                    "description": "A field for a designated name for an edge. Example: an official name for a trail.",
                     "type": "string"
                 },
                 "surface": {
@@ -1620,20 +1546,22 @@
                     "type": "string"
                 },
                 "width": {
-                    "description": "A field for width of a pathway in meters.",
+                    "description": "A field for width of an edge in meters.",
                     "maximum": 500,
                     "minimum": 0,
                     "type": "number"
                 }
             },
             "required": [
+                "_u_id",
+                "_v_id",
                 "highway"
             ],
             "type": "object"
         },
         "RolledCurb": {
             "additionalProperties": false,
-            "description": "A curb interface with a quarter-circle profile: traversing this curb is like going over half of a bump. Located where two pathways meet, physically at the location of the curb itself.",
+            "description": "A curb interface with a quarter-circle profile: traversing this curb is like going over half of a bump. Located where two edges meet, physically at the location of the curb itself.",
             "properties": {
                 "bbox": {
                     "anyOf": [
@@ -1718,6 +1646,9 @@
             "additionalProperties": false,
             "description": "Fields that apply to a rolled curb.",
             "properties": {
+                "_id": {
+                    "type": "string"
+                },
                 "brunnel": {
                     "description": "A field that indicates whether an entity is on a bridge, tunnel, or ford.",
                     "enum": [
@@ -1734,13 +1665,14 @@
                     "type": "string"
                 },
                 "layer": {
-                    "description": "A field that indicates the z-layer (integer) on which a pathway lies. If unset, a value of 0 is implied. Negative values are allowed.",
+                    "description": "A field that indicates the z-layer (integer) on which an edge lies. If unset, a value of 0 is implied. Negative values are allowed.",
                     "maximum": 10,
                     "minimum": -10,
                     "type": "integer"
                 }
             },
             "required": [
+                "_id",
                 "kerb"
             ],
             "type": "object"
@@ -1832,6 +1764,12 @@
             "additionalProperties": false,
             "description": "Fields that apply to a secondary street.",
             "properties": {
+                "_u_id": {
+                    "type": "string"
+                },
+                "_v_id": {
+                    "type": "string"
+                },
                 "brunnel": {
                     "description": "A field that indicates whether an entity is on a bridge, tunnel, or ford.",
                     "enum": [
@@ -1842,11 +1780,11 @@
                     "type": "string"
                 },
                 "description": {
-                    "description": "A free form text field for describing a pathway or point. May be pre-encoded in relevant pedestrian paths to assist with routing instructing or investigation of map features. For example, a description of the sidewalk in relation to a nearby street may be a useful textual description, such as \"NE of Main St.\" Can also be considered a flexible location to embed arbitrary information for specific use cases.",
+                    "description": "A free form text field for describing an edge of node. May be pre-encoded in relevant pedestrian paths to assist with routing instructing or investigation of map features. For example, a description of the sidewalk in relation to a nearby street may be a useful textual description, such as \"NE of Main St.\" Can also be considered a flexible location to embed arbitrary information for specific use cases.",
                     "type": "string"
                 },
                 "foot": {
-                    "description": "A field that indicates whether a pathway can be used by pedestrians. Is implied for a Footway entity and its subtypes.",
+                    "description": "A field that indicates whether an edge can be used by pedestrians. Is implied for a Footway entity and its subtypes.",
                     "type": "boolean"
                 },
                 "highway": {
@@ -1862,19 +1800,19 @@
                     "type": "number"
                 },
                 "layer": {
-                    "description": "A field that indicates the z-layer (integer) on which a pathway lies. If unset, a value of 0 is implied. Negative values are allowed.",
+                    "description": "A field that indicates the z-layer (integer) on which an edge lies. If unset, a value of 0 is implied. Negative values are allowed.",
                     "maximum": 10,
                     "minimum": -10,
                     "type": "integer"
                 },
                 "length": {
-                    "description": "A field for the length of a pathway in meters. This field is always inferred from the geometry.",
+                    "description": "A field for the length of an edge in meters. This field is always inferred from the geometry.",
                     "maximum": 5000,
                     "minimum": 0,
                     "type": "number"
                 },
                 "name": {
-                    "description": "A field for a designated name for a pathway. Example: an official name for a trail.",
+                    "description": "A field for a designated name for an edge. Example: an official name for a trail.",
                     "type": "string"
                 },
                 "surface": {
@@ -1891,13 +1829,15 @@
                     "type": "string"
                 },
                 "width": {
-                    "description": "A field for width of a pathway in meters.",
+                    "description": "A field for width of an edge in meters.",
                     "maximum": 500,
                     "minimum": 0,
                     "type": "number"
                 }
             },
             "required": [
+                "_u_id",
+                "_v_id",
                 "highway"
             ],
             "type": "object"
@@ -1989,6 +1929,12 @@
             "additionalProperties": false,
             "description": "Fields that apply to a service road.\nprimary street.",
             "properties": {
+                "_u_id": {
+                    "type": "string"
+                },
+                "_v_id": {
+                    "type": "string"
+                },
                 "brunnel": {
                     "description": "A field that indicates whether an entity is on a bridge, tunnel, or ford.",
                     "enum": [
@@ -1999,11 +1945,11 @@
                     "type": "string"
                 },
                 "description": {
-                    "description": "A free form text field for describing a pathway or point. May be pre-encoded in relevant pedestrian paths to assist with routing instructing or investigation of map features. For example, a description of the sidewalk in relation to a nearby street may be a useful textual description, such as \"NE of Main St.\" Can also be considered a flexible location to embed arbitrary information for specific use cases.",
+                    "description": "A free form text field for describing an edge of node. May be pre-encoded in relevant pedestrian paths to assist with routing instructing or investigation of map features. For example, a description of the sidewalk in relation to a nearby street may be a useful textual description, such as \"NE of Main St.\" Can also be considered a flexible location to embed arbitrary information for specific use cases.",
                     "type": "string"
                 },
                 "foot": {
-                    "description": "A field that indicates whether a pathway can be used by pedestrians. Is implied for a Footway entity and its subtypes.",
+                    "description": "A field that indicates whether an edge can be used by pedestrians. Is implied for a Footway entity and its subtypes.",
                     "type": "boolean"
                 },
                 "highway": {
@@ -2019,13 +1965,13 @@
                     "type": "number"
                 },
                 "layer": {
-                    "description": "A field that indicates the z-layer (integer) on which a pathway lies. If unset, a value of 0 is implied. Negative values are allowed.",
+                    "description": "A field that indicates the z-layer (integer) on which an edge lies. If unset, a value of 0 is implied. Negative values are allowed.",
                     "maximum": 10,
                     "minimum": -10,
                     "type": "integer"
                 },
                 "length": {
-                    "description": "A field for the length of a pathway in meters. This field is always inferred from the geometry.",
+                    "description": "A field for the length of an edge in meters. This field is always inferred from the geometry.",
                     "maximum": 5000,
                     "minimum": 0,
                     "type": "number"
@@ -2044,13 +1990,15 @@
                     "type": "string"
                 },
                 "width": {
-                    "description": "A field for width of a pathway in meters.",
+                    "description": "A field for width of an edge in meters.",
                     "maximum": 500,
                     "minimum": 0,
                     "type": "number"
                 }
             },
             "required": [
+                "_u_id",
+                "_v_id",
                 "highway"
             ],
             "type": "object"
@@ -2123,6 +2071,12 @@
                     "additionalProperties": false,
                     "description": "Properties associated with this feature.",
                     "properties": {
+                        "_u_id": {
+                            "type": "string"
+                        },
+                        "_v_id": {
+                            "type": "string"
+                        },
                         "footway": {
                             "enum": [
                                 "sidewalk"
@@ -2137,6 +2091,8 @@
                         }
                     },
                     "required": [
+                        "_u_id",
+                        "_v_id",
                         "footway",
                         "highway"
                     ]
@@ -2243,6 +2199,12 @@
             "additionalProperties": false,
             "description": "Fields that apply to a tertiary street.",
             "properties": {
+                "_u_id": {
+                    "type": "string"
+                },
+                "_v_id": {
+                    "type": "string"
+                },
                 "brunnel": {
                     "description": "A field that indicates whether an entity is on a bridge, tunnel, or ford.",
                     "enum": [
@@ -2253,11 +2215,11 @@
                     "type": "string"
                 },
                 "description": {
-                    "description": "A free form text field for describing a pathway or point. May be pre-encoded in relevant pedestrian paths to assist with routing instructing or investigation of map features. For example, a description of the sidewalk in relation to a nearby street may be a useful textual description, such as \"NE of Main St.\" Can also be considered a flexible location to embed arbitrary information for specific use cases.",
+                    "description": "A free form text field for describing an edge of node. May be pre-encoded in relevant pedestrian paths to assist with routing instructing or investigation of map features. For example, a description of the sidewalk in relation to a nearby street may be a useful textual description, such as \"NE of Main St.\" Can also be considered a flexible location to embed arbitrary information for specific use cases.",
                     "type": "string"
                 },
                 "foot": {
-                    "description": "A field that indicates whether a pathway can be used by pedestrians. Is implied for a Footway entity and its subtypes.",
+                    "description": "A field that indicates whether an edge can be used by pedestrians. Is implied for a Footway entity and its subtypes.",
                     "type": "boolean"
                 },
                 "highway": {
@@ -2273,19 +2235,19 @@
                     "type": "number"
                 },
                 "layer": {
-                    "description": "A field that indicates the z-layer (integer) on which a pathway lies. If unset, a value of 0 is implied. Negative values are allowed.",
+                    "description": "A field that indicates the z-layer (integer) on which an edge lies. If unset, a value of 0 is implied. Negative values are allowed.",
                     "maximum": 10,
                     "minimum": -10,
                     "type": "integer"
                 },
                 "length": {
-                    "description": "A field for the length of a pathway in meters. This field is always inferred from the geometry.",
+                    "description": "A field for the length of an edge in meters. This field is always inferred from the geometry.",
                     "maximum": 5000,
                     "minimum": 0,
                     "type": "number"
                 },
                 "name": {
-                    "description": "A field for a designated name for a pathway. Example: an official name for a trail.",
+                    "description": "A field for a designated name for an edge. Example: an official name for a trail.",
                     "type": "string"
                 },
                 "surface": {
@@ -2302,13 +2264,15 @@
                     "type": "string"
                 },
                 "width": {
-                    "description": "A field for width of a pathway in meters.",
+                    "description": "A field for width of an edge in meters.",
                     "maximum": 500,
                     "minimum": 0,
                     "type": "number"
                 }
             },
             "required": [
+                "_u_id",
+                "_v_id",
                 "highway"
             ],
             "type": "object"
@@ -2381,6 +2345,12 @@
                     "additionalProperties": false,
                     "description": "Properties associated with this feature.",
                     "properties": {
+                        "_u_id": {
+                            "type": "string"
+                        },
+                        "_v_id": {
+                            "type": "string"
+                        },
                         "footway": {
                             "enum": [
                                 "traffic_island"
@@ -2395,6 +2365,8 @@
                         }
                     },
                     "required": [
+                        "_u_id",
+                        "_v_id",
                         "footway",
                         "highway"
                     ]
@@ -2420,16 +2392,13 @@
             "items": {
                 "anyOf": [
                     {
+                        "$ref": "#/definitions/BareNode"
+                    },
+                    {
                         "$ref": "#/definitions/CurbRamp"
                     },
                     {
-                        "$ref": "#/definitions/FireHydrant"
-                    },
-                    {
                         "$ref": "#/definitions/FlushCurb"
-                    },
-                    {
-                        "$ref": "#/definitions/PowerPole"
                     },
                     {
                         "$ref": "#/definitions/RaisedCurb"


### PR DESCRIPTION
Hello! This is a proposal to include and elevate network primitives within the OpenSidewalks Schema. This proposal includes these core changes:

- Points have been split into two entities types: Nodes and Points. The former is part of the graph structure, the latter is not.
- Pathways have been renamed to Edges, reflecting their inherent network properties.
- Nodes require the definition of an `_id` field, a vertex identifier that is referenced by Edges.
- Edges require the definition of `_u_id` and `_v_id` fields, references to start and end Node `_ids`, respectively.

These changes have two primary motivations:

1. The need to represent and construct a network directly from an OpenSidewalks Schema dataset.
2. Placing an emphasis on the network structure more clearly communicates the purpose of the OpenSidewalks Schema and the paradigm it uses.

Included below is the full RFC description. Please provide any feedback on changes / this proposal ASAP, as we would like to integrate this change for use by outside orgs within the next week or two.

### OpenSidewalks Schema version base

- OpenSidewalks Schema version base: [commit e6ea35e](https://github.com/OpenSidewalks/OpenSidewalks-Schema/commit/e6ea35e7b58388da5815b86b4d3ebae3d7316f95)
- Draft start date: 2022-03-04
- Last updated: 2022-03-04

### Motivation

The OpenSidewalks Schema standard is intended to capture network data about pedestrian spaces, but currently lacks primitives by which to describe network relationships - let alone requiring such data. Without node IDs on points and references to start/end nodes on pathways, the topological structure of OpenSidewalks Schema elements is left ambiguous; whether elements are connected is left up to downstream interpretation using spatial methods such as clustering line endpoints.
This proposal recommends the adoption of such primitives as well as the relabeling of OpenSidewalks Schema types to emphasize that the schema is one of network elements. Once adopted, interpretation of OpenSidewalks data as a network will become unambiguous: a graph may be constructed by first (1) reading all node data and then (2) reading all edge data, checking that all edge references are to previously seen nodes.

### Background

#### Relevance to the current schema

The changes required impact all top-level schema elements, currently described as either Points (elements that have a single longitude-latitude position) and Pathways (linear elements, i.e. LineStrings). Under this proposal, Points are considered to be equivalent to the nodes of a network and Pathways are considered to be equivalent to edges.
This proposal does not change any existing properties on entities described by the OpenSidewalks Schema and is entirely additive.

#### Relevance to OpenStreetMap

OpenStreetMap data is inherently topological, with primitives called “nodes” and “ways” describing all points and pathways with an efficient structure whereby ways (describing lines and areas) refer to nodes, location data optionally enriched with key-value metadata, rather than describing their own geometrical information separately. These data can therefore be interpreted into a network structure unambiguously: OpenStreetMap nodes can be understood directly as graph nodes and OpenStreetMap ways can be thought of as paths over a set of non-explicit edges; a graph structure may be interpreted from ways based on the set of nodes they are listed as traversing.

OpenSidewalks Schema data may be derived unambiguously from OpenStreetMap as a directed multigraph wherein nodes are a 1-to-1 mapping to OpenStreetMap nodes, edges are a subset of way paths, and there may be more than one edge starting and ending at a given pair of nodes (hence the multi- part of multigraph). Similarly, OpenSidewalks Schema data not derived from OpenStreetMap may be transformed into an OpenStreetMap format unambiguously from a network format - though conflation with existing data prior to entering it into the global shared OSM database may still be necessary.

### Data Model Changes

#### Proposed change 1: Rename elements to emphasis network abstractions

##### Data model

If the OpenSidewalks Schema represents a network, then its elements should be named like network elements. This proposal suggests changing the name of the “Point” entity to “Node” and the name of the “Pathway” entity to “Edge”. This will head off ambiguities in interpretation of our elements, particularly relatively to the rules we have already described, such as the fact that “Pathways” should share endpoints if they are to be considered connected - or, per this proposal, that they share node references.

Some of the previous "Point" entities are not network elements, such as a fire hydrant. These entities will still be defined as Point entities, so the schema would now have 3 entity types: Nodes, Edges, and Points.

This change to the data model is currently restricted entirely to documentation: per our schema, there is no metadata that explicitly states anything about an entity as being a “Point” or “Pathway”, nor will there be metadata that states an entity is a “Node” or “Edge”.

##### Network element interactions

N/A

##### OpenStreetMap tagging implications

N/A

Note: efforts should be taken to clarify the difference between OpenStreetMap Nodes and OpenSidewalks Nodes. They can be interconverted but have slightly different meanings, as Edges have their own geometries in our model whereas Ways only reference Nodes in OpenStreetMap.

#### Proposed change 2: Node identifier

##### Data model

In basic graph theory, nodes are defined simply as symbols that are referenced by edges. A Node (currently, “Point”) in our current schema has other data attached to it, of course (because our graph is embedded in space and has key-value metadata), but what is currently missing is such a symbol that uniquely identifies that entity over time.

Per this proposal, Node entities should have a new field added with a key of “_id” and value of a string that is required to be unique within the dataset. There are further constraints that could be valuable to add to the value of the “_id” field but should be considered part of future work, such as whether it should actually be a UUID and whether there are value patterns that distinguish the source of the node identifier (OpenStreetMap, an internal dataset, a made-up number).

##### Network element interactions

N/A

##### OpenStreetMap tagging implications

N/A. 

Note: OpenSidewalks Schema Node identifiers may simply be stringified OSM Node IDs.

#### Proposed change 3: Edge identifier

##### Data model

In basic graph theory, edges are defined simply as a node tuple, usually references as a (u,v) pair. An Edge (currently, “Pathway”) in our current schema has other data attached to it, of course (because our graph is embedded in space and has key-value metadata), but what is currently missing is such references that uniquely identify an entity over time - and the graph structure beyond spatial inference.

Per this proposal, Edge entities should have a new field added with keys of “_u_id and “_v_id” and values of strings, themselves references to Node “id” values within the current dataset. Abstractly, these can be thought of as foreign keys, but in serialized form (how we usually describe our entities), they are strings, i.e. the same values as Node “_id” fields.

##### Network element interactions

N/A

##### OpenStreetMap tagging implications

N/A

#### Proposed change 4: Include bare node entities

##### Data model

If every Edge needs to reference two Nodes, then we will frequently encounter the case where a Node will have no metadata and serve only to describe the graph structure itself. However, there is currently no Node (“Point”) entity that is entirely free of metadata - only Nodes that represent features like curb ramps or fire hydrants are defined.

Per this proposal, there should be a bare Node entity defined that contains only geospatial information and the “_id” field. This will be entitled, “Bare Node”.

##### Network element interactions

N/A

##### OpenStreetMap tagging implications

N/A