### PR TITLE
Fix formatting in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -979,7 +979,7 @@ Whether a curb ramp or Edge has a tactile (textured) surface.
 
 ##### <a name="field-crossing"></a> crossing
 
-From OpenStreetMap
+*From OpenStreetMap*
 
 Type of street crossing - marked or unmarked. When derived from
 OpenStreetMap data, the crossing key undergoes various conversions due


### PR DESCRIPTION
Adds missing italic formatting for "From OpenStreetMap".

(Sidenote: I would also seperate ie. "`barrier=kerb, kerb=raised`" into "`barrier=kerb`, `kerb=raised`" to indicate they're individual `k=v` pairs, or alternatively use a code block of two lines. But this up to how you call the field in the schema possibly.)