### PR TITLE
Add markings:crossings=* and deprecated crossing=marked/unmarked

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,7 +448,7 @@ LineString
 
 All [optional fields of footway](#edge-footway-optional-fields)
 
-[crossing](#field-crossing)
+[crossing:markings](#field-crossing_markings)
 
 ### <a name="edge-traffic_island"></a> Traffic Island
 
@@ -977,19 +977,58 @@ Whether a curb ramp or Edge has a tactile (textured) surface.
 
 ###### *Value type*: boolean
 
-##### <a name="field-crossing"></a> crossing
+##### <a name="field-crossing_markings"></a> crossing:markings
 
 *From OpenStreetMap*
 
-Type of street crossing - marked or unmarked. When derived from
-OpenStreetMap data, the crossing key undergoes various conversions due
-to fragmentation. Both the uncontrolled and zebra values are converted
-into marked and the traffic\_signals value is ignored.
+Whether a pedestrian street crossing has ground markings (and, optionally, what
+type of markings exist). When derived from OpenStreetMap data, the
+crossing:markings field may be derived not only from the identical
+`crossing:markings` tag in OpenStreetMap, but from any unambiguous tags in the
+problematic `crossing=*` tag, such as `crossing=marked` -->
+`crossing:markings=yes` and `crossing=unmarked` --> `crossing:markings=no`, and
+`crossing=zebra` --> `crossing:markings=yes`.
 
 ###### *Value type*: enum
 
 ###### *Enumerated values*:
 
--   marked: a marked crossing
+-   yes: The crossing has surface markings but the type is unspecified.
 
--   unmarked: an unmarked crossing
+-   no: The crossing has no surface markings.
+
+-   surface: There is a surface change but no distinct markings.
+
+-   lines: There are only two parallel lines to indicate the outline of the
+crossing.
+
+-   lines:paired: The same as `crossing:markings=lines` but each line is
+actually two very-close parallel lines (for a total of 4 lines).
+
+-   dashes: There are only two parallel dashed lines to indicate the outline of
+the crossing.
+
+-   dots: There are only two parallel dotted lines (square/round markings with
+significant distance between them) to indicate the outline of the crossing.
+
+-   zebra: The crossing is only marked by regularly spaced bars along its
+length.
+
+-   zebra:double: The same as `crossing:markings=zebra` but there are two sets
+of regularly spaced bars with a small gap between them.
+
+-   zebra:paired: The same as `crossing:markings=zebra` but each bar is made up
+of two smaller bars (i.e. there's a small gap between smaler bars).
+
+-   zebra:bicolour: The same as `crossing:markings=zebra` but there are the
+bars and gaps are made of two alternating colors.
+
+-   ladder: The same as combining `crossing:markings=zebra` and
+`crossing:markings=lines`: horizontal bars but with linears outlines enclosing
+the crossing.
+
+-   skewed: The same as `crossing:markings=ladder` but the horizontal bars are
+at a slight diagonal (~30 degree shift) - they're skewed.
+
+-   ladder:paired: The same as `crossing:markings=ladder` but the horizontal
+bars are actually made up of two very-close smaller bars.

--- a/jsonschema/src/edges/crossing.ts
+++ b/jsonschema/src/edges/crossing.ts
@@ -2,6 +2,7 @@ import { Feature, LineString } from "geojson";
 
 import { BaseEdgeFields } from "./base-edge-fields";
 import { FootwayFields } from "./footway";
+import { CrossingMarkings } from "../fields";
 
 /**
  * Fields that identify a crossing.
@@ -15,7 +16,7 @@ interface CrossingIdentifyingFields extends BaseEdgeFields {
  * Fields that apply to a crossing.
  */
 interface CrossingFields extends CrossingIdentifyingFields, FootwayFields {
-  crossing?: "marked" | "unmarked";
+  "crossing:markings"?: CrossingMarkings;
 }
 
 /**

--- a/jsonschema/src/fields.ts
+++ b/jsonschema/src/fields.ts
@@ -5,7 +5,8 @@ export type Brunnel = "bridge" | "ford" | "tunnel";
 /**
  * A field for the type of street crossing - marked or unmarked. When derived from OpenStreetMap data, the crossing key undergoes various conversions due to fragmentation. Both the uncontrolled and zebra values are converted into marked and the traffic\_signals value is ignored.
  */
-export type Crossing = "marked" | "unmarked";
+export type CrossingMarkings = "yes" | "no" | "surface" | "lines" | "lines:paired" | "dashes" | "dots" | "zebra" | "zebra:double" | "zebra:paired" | "zebra:bicolour" | "ladder" | "skewed" | "ladder:paired";
+
 /**
  * A free form text field for describing an edge of node. May be pre-encoded in relevant pedestrian paths to assist with routing instructing or investigation of map features. For example, a description of the sidewalk in relation to a nearby street may be a useful textual description, such as "NE of Main St." Can also be considered a flexible location to embed arbitrary information for specific use cases.
  */

--- a/opensidewalks.schema.json
+++ b/opensidewalks.schema.json
@@ -368,10 +368,23 @@
                     ],
                     "type": "string"
                 },
-                "crossing": {
+                "crossing:markings": {
+                    "description": "A field for the type of street crossing - marked or unmarked. When derived from OpenStreetMap data, the crossing key undergoes various conversions due to fragmentation. Both the uncontrolled and zebra values are converted into marked and the traffic\\_signals value is ignored.",
                     "enum": [
-                        "marked",
-                        "unmarked"
+                        "dashes",
+                        "dots",
+                        "ladder",
+                        "ladder:paired",
+                        "lines",
+                        "lines:paired",
+                        "no",
+                        "skewed",
+                        "surface",
+                        "yes",
+                        "zebra",
+                        "zebra:bicolour",
+                        "zebra:double",
+                        "zebra:paired"
                     ],
                     "type": "string"
                 },


### PR DESCRIPTION
# Schema Change Proposal

## Short description

This schema change proposal would replace the use of `crossing=marked/unmarked` with `crossing:markings=*`. `crossing:markings=*` is a new (technically currently proposed, but is very likely to be accepted tomorrow) OpenStreetMap tagging standard that addresses long-running problems with ambiguity and non-orthogonality in the `crossing=*` tagging schema. This change will disambiguate information about pedestrian crossings and whether they have markings, including new and more detailed descriptions of ground markings.

## Purpose

This schema change is in response to a beneficial tagging change in the OpenStreetMap community that is in alignment with our long-running hope of being able to map crossing markings and crossing signalization separately. While we could use our existing `crossing=marked/unmarked` entity definitions and remain largely compatible, there is value in having close alignment with high-quality schemas in OpenStreetMap, and because this schema is in the pre-alpha stages it would be good to align at this time.

## Longer description

The OpenSidewalks Schema currently keeps track of markings on pedestrian street crossings using the `crossing=marked/unmarked` field. This field simply indicates the presence or absence of ground markings for a given pedestrian street crossing. In OpenStreetmap, the `crossing` key can also be used with values like `uncontrolled` or `traffic_signals` that don't reliably mean that there are ground markings present. The decision to use only the `marked` and `unmarked` values reflects our attempt (and hope) that OpenStreetMap et al would use separate and unambiguous schemas in the future; that ground markings and signalization would be mapped separately. The new tagging schema, `crossing:markings`, represents a significant step towards that reality by making ground markings a *property of* the crossing rather than a distinct category. Full disambiguation will also require that signalization (pedestrian light signals, sounds, APS devices) be consistently treated as one or more properties as well.

This proposal recognizes that our current schema is a workaround that was used in anticipation of a tagging schema like OpenStreetMap's new `crossing:markings=*`. Now that this new, better tagging schema exists, we should reflect it directly. In addition to matching the mainline OpenStreetMap tagging standards, this tagging schema also brings the potential for more information by having values for specific marking *types*, such as `lines` (just an outline), `surface` (there's only a surface difference), or `ladder` (there are also horizontal bars along the path). We should capture these specific descriptions in our schema to aid with navigation and also because different markings types imply different rights of way and cross-traffic control in certain locales.

This proposal specifically (1) deprecates the use of `crossing=marked/unmarked` and (2) adds the `crossing:markings=*` tag, adding all of its current values. The new values can be seen in the README or in `jsonschema/src/fields.ts`.

## Tasks needed to implement this change

Note: we should automate as many of these tasks as we can going forward.

[*] The `README.md` (draft schema description)
[*] The TypeScript code base that generates a `jsonschema` for OpenSidewalks Schema GeoJSON.
[*] The `jsonschema` for OpenSidewalks Schema GeoJSON. 
[] Update the `jsonschema` and the `README.md` to be versioned and indicate version `0.1.0`.
[] After accepting this pull request, immediately create a release (version `0.1.0`) with a note of the changes.
[] Create a changelog file?